### PR TITLE
Pytest Object Getter v0.1.0 Release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,8 +52,8 @@ jobs:
         echo "DIST_DIR=dist" >> $GITHUB_ENV
 
         mkdir "$DIST_DIR"
-        mv ".tox/${DIST_DIR}/cookiecutter_python-${PKG_VERSION}.tar.gz" "${DIST_DIR}"
-        mv ".tox/${DIST_DIR}/cookiecutter_python-${PKG_VERSION}-py3-none-any.whl" "${DIST_DIR}"
+        mv ".tox/${DIST_DIR}/pytest_object_getter-${PKG_VERSION}.tar.gz" "${DIST_DIR}"
+        mv ".tox/${DIST_DIR}/pytest_object_getter-${PKG_VERSION}-py3-none-any.whl" "${DIST_DIR}"
         tox -e check -vv -s false
 
     - name: Upload Source & Wheel distributions as Artefacts


### PR DESCRIPTION
0.1.0 (2022-06-02)
==================

| This is the first ever release of the **pytest_object_getter** Python Package.
| The package is open source and is part of the **Pytest Object Getter** Project.
| The project is hosted in a public repository on github at https://github.com/boromir674/pytest-object-getter
| The project was scaffolded using the `Cookiecutter Python Package`_ (cookiecutter) Template at https://github.com/boromir674/cookiecutter-python-package/tree/master/src/cookiecutter_python

| Scaffolding included:

- **CI Pipeline** running on Github Actions at https://github.com/boromir674/pytest-object-getter/actions
  - `Test Workflow` running a multi-factor **Build Matrix** spanning different `platform`'s and `python version`'s
    1. Platforms: `ubuntu-latest`, `macos-latest`
    2. Python Interpreters: `3.6`, `3.7`, `3.8`, `3.9`, `3.10`

- Automated **Test Suite** with parallel Test execution across multiple cpus.
  - Code Coverage
- **Automation** in a 'make' like fashion, using **tox**
  - Seamless `Lint`, `Type Check`, `Build` and `Deploy` *operations*