### PR TITLE
Pytest Object Getter v1.0.0 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+1.0.0 (2022-06-02)
+==================
+
+First release declared stable after being used 'in the wild'!
+
+Changes
+^^^^^^^
+
+build
+"""""
+- add shinxcontrib-spelling dependency in 'docs' extras
+
+
 0.1.0 (2022-06-02)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -186,9 +186,9 @@ License
 
 .. Github Releases & Tags
 
-.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/pytest-object-getter/v0.1.0/master?color=blue&logo=github
+.. |commits_since_specific_tag_on_master| image:: https://img.shields.io/github/commits-since/boromir674/pytest-object-getter/v1.0.0/master?color=blue&logo=github
     :alt: GitHub commits since tagged version (branch)
-    :target: https://github.com/boromir674/pytest-object-getter/compare/v0.1.0..master
+    :target: https://github.com/boromir674/pytest-object-getter/compare/v1.0.0..master
 
 .. |commits_since_latest_github_release| image:: https://img.shields.io/github/commits-since/boromir674/pytest-object-getter/latest?color=blue&logo=semver&sort=semver
     :alt: GitHub commits since latest release (by SemVer)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 ## Setuptools specific information
 name = pytest_object_getter
-version = 0.1.0
+version = 1.0.0
 # renders on pypi as subtitle
 description = Import any object from a 3rd party module while mocking its namespace on demand.
 long_description = file: README.rst
@@ -17,7 +17,7 @@ maintainer_email = k.lampridis@hotmail.com
 # represents the web home page of the project
 url = https://github.com/boromir674/pytest-object-getter
 
-download_url = https://github.com/boromir674/pytest-object-getter/archive/v0.1.0.tar.gz
+download_url = https://github.com/boromir674/pytest-object-getter/archive/v1.0.0.tar.gz
 
 ## PyPi specific information
 project_urls =

--- a/src/pytest_object_getter/__init__.py
+++ b/src/pytest_object_getter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '1.0.0'
 
 __all__ = [
     'get_object',


### PR DESCRIPTION
1.0.0 (2022-06-02)
==================

Changes
-------

build
"""""
- add shinxcontrib-spelling dependency in 'docs' extras